### PR TITLE
Escape alchemist path

### DIFF
--- a/plugin/helpex.vim
+++ b/plugin/helpex.vim
@@ -16,7 +16,7 @@ let s:elixir_module = '[A-Z][[:alnum:]_]\+\([A_Z][[:alnum:]_]+\)*'
 
 " plugin/helpex.vim
 " TODO Make env configurable (esp while we're writing tests?)
-let s:alchemist = expand("<sfile>:p:h:h") . '/alchemist-server/run.exs'
+let s:alchemist = '"' . expand("<sfile>:p:h:h") . '/alchemist-server/run.exs"'
 let s:startcmd = 'elixir ' . s:alchemist . ' dev'
 
 let s:process = {}


### PR DESCRIPTION
Otherwise, when you have a space in your path, starting the alchemist server will not work. You will just get the `['exit', 1]` error without any additional error messages when running `helpex#status`.

Disclaimer: I have never used vimscript before, so maybe there is a better way to do it - but I tested it this way and it seems to work fine.
